### PR TITLE
fix crashing when stubs undefined

### DIFF
--- a/both/stub_meteor_call.coffee
+++ b/both/stub_meteor_call.coffee
@@ -1,22 +1,23 @@
-_original = Meteor.call
+if stubs?
+  _original = Meteor.call
 
-stubMeteorMethod = (methodName, error=null, success=null) ->
-  s = Meteor.call
-  spy = sinon.spy()
-  Meteor.call = () =>
-    if arguments[0] == methodName
-      lastArg = _.last(arguments)
-      spy()
-      if typeof lastArg == 'function'
-        lastArg(error, success)
-    else
-      s.apply(@, arguments)
-  return spy
+  stubMeteorMethod = (methodName, error=null, success=null) ->
+    s = Meteor.call
+    spy = sinon.spy()
+    Meteor.call = () =>
+      if arguments[0] == methodName
+        lastArg = _.last(arguments)
+        spy()
+        if typeof lastArg == 'function'
+          lastArg(error, success)
+        else
+          s.apply(@, arguments)
+    return spy
 
-restoreMethodStubs = () ->
-  Meteor.call = _original
+  restoreMethodStubs = () ->
+    Meteor.call = _original
 
-_restoreAll = stubs.restoreAll
-stubs.restoreAll = () ->
-  _restoreAll.apply(this)
-  restoreMethodStubs()
+  _restoreAll = stubs.restoreAll
+  stubs.restoreAll = () ->
+    _restoreAll.apply(this)
+    restoreMethodStubs()


### PR DESCRIPTION
This fixes https://github.com/Hausor/test-helpers/issues/1

I was getting the crash mentioned in the above issue due to `stubs` not being defined while in production. This simply wraps the stub helpers in an if statement to check if `stubs` is defined.

This works for me on in development and production on my local machine.
